### PR TITLE
Added fat jar maven plugin build

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,18 @@ To see the generated PUML file, please click [here](examples/swagger.puml)
 
 ![Swagger-Class-Diagram-Sample](examples/swagger.svg)
 
+### Building:
+
+```
+mvn package
+```
+
+The jar is built with dependencies and placed in the root of the project.
+
 ### Usage:
 
 ```
-java -cp openapi2puml.jar org.openapi2puml.openapi.OpenApi2PlantUML [options]
+java -jar openapi2puml.jar [options]
 
 -i {Path of Swagger Definition (Can be either Yaml or json)}
 -o {Target location where Puml File and Image should generated}

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,33 @@
 					<check />
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+					<archive>
+						<manifest>
+							<addClasspath>true</addClasspath>
+							<mainClass>org.openapi2puml.openapi.OpenApi2PlantUML</mainClass>
+						</manifest>
+					</archive>
+					<outputDirectory>${project.parent.basedir}</outputDirectory>
+					<finalName>openapi2puml</finalName>
+					<appendAssemblyId>false</appendAssemblyId>
+				</configuration>
+				<executions>
+					<execution>
+						<id>assemble-all</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
fixes #5 in order to have a jar built with dependencies to make it easier to run the project on the command-line.

The readme.md is also updated to reflect this.

This PR was originally created on the main Swagger2puml repository by @dgileadi - https://github.com/kicksolutions/swagger2puml/pull/40