### PR TITLE
Bug fix for issues 27 and 28

### DIFF
--- a/openapi2puml-core/src/main/java/org/openapi2puml/openapi/OpenApi2PlantUML.java
+++ b/openapi2puml-core/src/main/java/org/openapi2puml/openapi/OpenApi2PlantUML.java
@@ -42,9 +42,9 @@ public class OpenApi2PlantUML {
         cliArgs.getArgumentValue("-generateDefinitionModelOnly", "false"));
     boolean includeCardinality = Boolean.parseBoolean(cliArgs.getArgumentValue("-includeCardinality", "true"));
     boolean generateSvg = Boolean.parseBoolean(cliArgs.getArgumentValue("-generateSvg", "true"));
-
+    boolean generatePng  = Boolean.parseBoolean(cliArgs.getArgumentValue("-generatePng", "true"));
     if (StringUtils.isNotEmpty(specFile) && StringUtils.isNotEmpty(output)) {
-      process(specFile, output, generateDefinitionModelOnly, includeCardinality, generateSvg);
+      process(specFile, output, generateDefinitionModelOnly, includeCardinality, generateSvg, generatePng);
     } else {
       LOGGER.error(USAGE);
     }
@@ -55,8 +55,8 @@ public class OpenApi2PlantUML {
    * @param output
    */
   private void process(String specFile, String output, boolean generateDefinitionModelOnly, boolean includeCardinality,
-                       boolean generateSvg) {
+                       boolean generateSvg, boolean generatePng) {
     PlantUMLGenerator generator = new PlantUMLGenerator();
-    generator.transformOpenApi2Puml(specFile, output, generateDefinitionModelOnly, includeCardinality, generateSvg);
+    generator.transformOpenApi2Puml(specFile, output, generateDefinitionModelOnly, includeCardinality, generateSvg, generatePng);
   }
 }

--- a/openapi2puml-core/src/main/java/org/openapi2puml/openapi/plantuml/PlantUMLGenerator.java
+++ b/openapi2puml-core/src/main/java/org/openapi2puml/openapi/plantuml/PlantUMLGenerator.java
@@ -17,7 +17,7 @@ public class PlantUMLGenerator {
   }
 
   public void transformOpenApi2Puml(String specFile, String output, boolean generateDefinitionModelOnly,
-                                    boolean includeCardinality, boolean generateSvg) {
+                                    boolean includeCardinality, boolean generateSvg, boolean generatePng) {
     File swaggerSpecFile = new File(specFile);
     File targetLocation = new File(output);
 
@@ -34,7 +34,10 @@ public class PlantUMLGenerator {
         LOGGER.info("Successfully Created Plant UML output file!");
 
         if (generateSvg) {
-          generateUmlDiagramFile(pumlPath, targetLocation);
+          generateUmlDiagramFile(pumlPath, FileFormat.SVG);
+        }
+        if (generatePng) {
+          generateUmlDiagramFile(pumlPath, FileFormat.PNG);
         }
       } catch (Exception e) {
         // TODO - Replace with better error message
@@ -48,9 +51,10 @@ public class PlantUMLGenerator {
     }
   }
 
-  private void generateUmlDiagramFile(String plantUmlFilePath, File targetOutputFile) throws Exception {
-    SourceFileReader sourceFileReader = new SourceFileReader(new File(plantUmlFilePath), targetOutputFile);
-    sourceFileReader.setFileFormatOption(new FileFormatOption(FileFormat.SVG));
+  private void generateUmlDiagramFile(String plantUmlFilePath, FileFormat format) throws Exception {
+    File pumlFile = new File(plantUmlFilePath);
+    SourceFileReader sourceFileReader = new SourceFileReader(pumlFile, pumlFile.getParentFile());
+    sourceFileReader.setFileFormatOption(new FileFormatOption(format));
     sourceFileReader.getGeneratedImages();
   }
 }

--- a/openapi2puml-core/src/main/java/org/openapi2puml/openapi/plantuml/vo/ClassRelation.java
+++ b/openapi2puml-core/src/main/java/org/openapi2puml/openapi/plantuml/vo/ClassRelation.java
@@ -24,7 +24,8 @@ public class ClassRelation {
   }
 
   public String getTargetClass() {
-    return targetClass;
+    if (targetClass != null && targetClass.contains("-")) return "\"" + targetClass + "\"";
+    else return targetClass;
   }
 
   public void setTargetClass(String targetClass) {
@@ -56,7 +57,8 @@ public class ClassRelation {
   }
 
   public String getSourceClass() {
-    return sourceClass;
+    if (sourceClass != null && sourceClass.contains("-")) return "\"" + sourceClass + "\"";
+    else return sourceClass;
   }
 
   public void setSourceClass(String sourceClass) {

--- a/openapi2puml-core/src/main/resources/puml.mustache
+++ b/openapi2puml-core/src/main/resources/puml.mustache
@@ -4,8 +4,8 @@ set namespaceSeparator none
 
 {{#classDiagrams}}
 {{#isClass}}class{{/isClass}} {{^isClass}}enum{{/isClass}} {{className}} {{#superClass}} < ? extends {{superClass}}> {{/superClass}}{
-	 {{#fields}}	
-	 - {{#name}}{{name}}{{/name}} {{#dataType}}<b>:{{dataType}}</b>{{/dataType}} 
+	 {{#fields}}
+	 - {{#name}}{{name}}{{/name}} {{#dataType}}<b>:{{dataType}}</b>{{/dataType}}
 	 {{/fields}}
 }
 
@@ -21,7 +21,7 @@ interface {{interfaceName}} {
 {{/interfaceDiagrams}}
 
 {{#entityRelations}}
-{{sourceClass}} {{#isExtension}}-->{{/isExtension}} {{#isComposition}}*--{{/isComposition}} {{#cardinality}}"{{cardinality}}"{{/cardinality}}  {{targetClass}} 
+{{&sourceClass}} {{#isExtension}}-->{{/isExtension}} {{#isComposition}}*--{{/isComposition}} {{#cardinality}}"{{cardinality}}"{{/cardinality}}  {{&targetClass}}
 {{/entityRelations}}
 
 note as N1

--- a/openapi2puml-core/src/test/java/org/openapi2puml/openapi/plantuml/PlantUMLGeneratorTest.java
+++ b/openapi2puml-core/src/test/java/org/openapi2puml/openapi/plantuml/PlantUMLGeneratorTest.java
@@ -27,7 +27,7 @@ class PlantUMLGeneratorTest {
     boolean includeCardinality = true;
     boolean generateSvg = true;
 
-    generator.transformOpenApi2Puml(specFile, outputPath, generateDefinitionModelOnly, includeCardinality, generateSvg);
+    generator.transformOpenApi2Puml(specFile, outputPath, generateDefinitionModelOnly, includeCardinality, generateSvg, false);
 
     assertTrue(new File(outputPath + "/" + DEFAULT_PLANT_UML_FILENAME).exists(), "Expect PlantUML file to be generated");
   }
@@ -42,7 +42,7 @@ class PlantUMLGeneratorTest {
     boolean includeCardinality = true;
     boolean generateSvg = true;
 
-    generator.transformOpenApi2Puml(specFile, outputPath, generateDefinitionModelOnly, includeCardinality, generateSvg);
+    generator.transformOpenApi2Puml(specFile, outputPath, generateDefinitionModelOnly, includeCardinality, generateSvg, false);
 
     assertTrue(new File(outputPath + "/" + DEFAULT_PLANT_UML_FILENAME).exists(), "Expect PlantUML file to be generated");
   }
@@ -57,7 +57,7 @@ class PlantUMLGeneratorTest {
     boolean includeCardinality = true;
     boolean generateSvg = true;
 
-    generator.transformOpenApi2Puml(specFile, outputPath, generateDefinitionModelOnly, includeCardinality, generateSvg);
+    generator.transformOpenApi2Puml(specFile, outputPath, generateDefinitionModelOnly, includeCardinality, generateSvg, false);
 
     File plantUmlFile = new File(outputPath + "/" + DEFAULT_PLANT_UML_FILENAME);
     String stringToFind = "CatApi -->    ErrorMessage,WarningMessage";


### PR DESCRIPTION
27 is fixed by checking the source and target class and if the contain a "-" escape the class names with double quotes
in the vo file i need to unescape the class names in that section

For 27 I havent added tests but run my swagegr puml against it and it worked.... Sorry wont have time to spend into this project too much time so please review and accept if you want it in master, else it will live in my fork...

28 is fixed by removing the output folder path from the image generation, thus the svg will always be placed int he same folder as the puml which seems much more intuitive. As "compensation" for the "loss" of the bug I have added the generatePng param that now allows to also produce PNG files.

For 28 there have been no tests added due to the simplicity of the changes