### PR TITLE
Make docker image into an executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,5 @@ RUN pwd
 # VOLUME /tmp
 
 # FINAL COMMAND to be executed when a container is created
-CMD [ "java", "-jar", "/openapi2puml/openapi2puml.jar", "-i", "examples/swagger.yaml", "-o", "/openapi2puml/examples" ]
+# Add options when running with `docker run -it`
+ENTRYPOINT [ "java", "-jar", "/openapi2puml/openapi2puml.jar" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,14 @@
-# Docker multi-stage build
+# switched to debian image to be able to use plantuml, graphviz and dot
+FROM debian:stable
 
-# 1. Building the App with Maven
-FROM maven:3-jdk-11
+RUN apt-get update && apt-get install -y plantuml graphviz && rm -rf /var/cache/apt/archives/*
+RUN apt-get update && apt-get install -y maven && rm -rf /var/cache/apt/archives/*
 
-ADD . /openapi2puml
-WORKDIR /openapi2puml
+COPY . /app
+WORKDIR /app
+RUN mvn clean install -DskipTests=true -Dgpg.skip -Dmaven.javadoc.skip=true -B -V
+RUN echo -e '#! /bin/bash\njava -jar /app/openapi2puml.jar $*' > /usr/local/bin/swagger2puml\
+ && chmod +x /usr/local/bin/swagger2puml
 
-# Just echo so we can see, if everything is there :)
-RUN ls -l
-
-# Run Maven build
-RUN mvn clean install -DskipTests
-
-# DC - test if we can new see jar.....
-RUN ls -l
-RUN pwd
-
-# TODO - this part makes the final image include only the JDK but it misses
-# the correct copy of the jar to the final image. Currently building the whole project and dumping it to the
-# final image
-# Just using the build artifact and then removing the build-container
-# FROM openjdk:11-jdk
-
-# DC - copy jar somewhere I can see it
-# COPY openapi2puml.jar /openapi2puml/openapi2puml.jar
-# VOLUME /tmp
-
-# FINAL COMMAND to be executed when a container is created
-# Add options when running with `docker run -it`
-ENTRYPOINT [ "java", "-jar", "/openapi2puml/openapi2puml.jar" ]
+ENV LANG en_US.UTF-8
+ENTRYPOINT [ "java", "-jar", "openapi2puml.jar" ]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ and add command line options by using `docker run`, e.g.
 # Run a docker container
 $ sudo docker run --rm -it --name openapi2puml \
     -v $PWD/examples:/specs \
-    openapi2puml/openapi2puml -i specs/swagger.yaml -o specs
+    openapi2puml/openapi2puml -i /specs/swagger.yaml -o /specs
 ```
 
 A dockerhub repo exists here: https://hub.docker.com/r/openapi2puml/openapi2puml
@@ -86,7 +86,7 @@ $ sudo docker build -t openapi2puml .
 # Run a docker container
 $ sudo docker run --rm -it --name openapi2puml \
     -v $PWD/examples:/specs \
-    openapi2puml -i specs/swagger.yaml -o specs
+    openapi2puml -i /specs/swagger.yaml -o /specs
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -60,20 +60,34 @@ java -jar openapi2puml.jar [options]
 
 ```
 
-## **Experimental** Dockerized version of OpenAPI2Puml
+## Dockerized version of OpenAPI2Puml
 
-This is an experiment to use a docker container to run the tool.
-Currently it will just generate a plantuml file from the example swagger.yaml file
+It is also to use a docker container to run the tool. Simply mount a directory
+and add command line options by using `docker run`, e.g.
 
 ```bash
-# Build the image from the project
-$ sudo docker build -t openapi2puml-test-image .
-
 # Run a docker container
-$ sudo docker run -v $PWD/examples:/openapi2puml/examples -it openapi2puml-test-image
+$ sudo docker run --rm -it --name openapi2puml \
+    -v $PWD/examples:/specs \
+    openapi2puml/openapi2puml -i specs/swagger.yaml -o specs
 ```
 
 A dockerhub repo exists here: https://hub.docker.com/r/openapi2puml/openapi2puml
+
+To build and run a local copy, do the following:
+
+```bash
+# Obtain base image for build
+$ sudo docker pull maven:3-jdk-11  # needed since docker-hub pull restrictions
+
+# Build the image from the project
+$ sudo docker build -t openapi2puml .
+
+# Run a docker container
+$ sudo docker run --rm -it --name openapi2puml \
+    -v $PWD/examples:/specs \
+    openapi2puml -i specs/swagger.yaml -o specs
+```
 
 License
 ----


### PR DESCRIPTION
Address issue #18 by making docker image runnable via an `ENTRYPOINT` in the Dockerfile - see README.md for example usage